### PR TITLE
Changed import vue-echo to vue-tawk on README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ First you'll need to register the plugin
 Second you should had a account of https://www.tawk.to/
 
 ``` js
-import Tawk from 'vue-echo'
+import Tawk from 'vue-tawk'
   
 Vue.use(Tawk, {
-    tawkSrc: 'YOU_TAWK_SRC'
+    tawkSrc: 'YOU_TAWK_SRC e.g: https://embed.tawk.to/xxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxx'
 })
 ```
 


### PR DESCRIPTION
On the README file, this line `import Tawk from 'vue-echo'` when executed give an error because we doesn't install `vue-echo`, we installed  `vue-tawk`. So I changed this line to `import Tawk from 'vue-tawk'`.

And I add a example on the TAWK_SRC , because people you may think it's the code snippet that Tawk gives us and it's not , it's the src(link) inside the code snippet.