### PR TITLE
docs: fixed library import

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First you'll need to register the plugin
 Second you should had a account of https://www.tawk.to/
 
 ``` js
-import Tawk from 'vue-echo'
+import Tawk from 'vue-tawk'
   
 Vue.use(Tawk, {
     tawkSrc: 'YOU_TAWK_SRC'


### PR DESCRIPTION
Great work on the library! While testing it out, I noticed that it would work for me with import Tawk from 'vue-tawk', but on the doc it is importing from 'vue-echo'. The proposed change is to update that. Thanks!